### PR TITLE
Modularized code

### DIFF
--- a/llamaindex/chat_with_website/.env
+++ b/llamaindex/chat_with_website/.env
@@ -1,0 +1,5 @@
+PERSIST_DIR="./storage"
+BEDROCK_MODEL="anthropic.claude-instant-v1"
+AWS_PROFILE_NAME="aws_sol"
+CHAT_TEMPERATURE=0
+COLLECTION_NAME="bedrock-url-analyzer"

--- a/llamaindex/chat_with_website/main.py
+++ b/llamaindex/chat_with_website/main.py
@@ -1,20 +1,8 @@
 import streamlit as st
+from uiutils import build_page_structure
 
-st.set_page_config(
-    page_title="Chat with your WebPage",
-    page_icon="🔎",
-    layout="centered",
-    initial_sidebar_state="auto",
-    menu_items=None,
-)
+build_page_structure("RAG Demos", "🏠")
 
-with st.sidebar:
-    st.page_link("main.py", label="Home", icon="🏠")
-    st.page_link("pages/pdf.py", label="PDF", icon="📁")
-    st.page_link("pages/website.py", label="Website", icon="🌐")
-    st.page_link("pages/chat.py", label="Chat", icon="💬")
-
-st.title('🔎 RAG Demos 🔎')
 st.caption('Chat with your websites and documents using Amazon Bedrock.')
 
 st.subheader('Objective')

--- a/llamaindex/chat_with_website/pages/chat.py
+++ b/llamaindex/chat_with_website/pages/chat.py
@@ -1,136 +1,34 @@
 import streamlit as st
-from dotenv import load_dotenv
-import os
-import uuid
-
-from llama_index.llms.bedrock import Bedrock
-from llama_index.core import ServiceContext, StorageContext
-from llama_index.embeddings.bedrock import BedrockEmbedding
-
-# enabling debug
-from llama_index.core.callbacks import LlamaDebugHandler, CallbackManager
-
-# exceptions
-from botocore.exceptions import ClientError
-
-# import the object for message
-from llama_index.core.llms import ChatMessage, MessageRole
+# import the utils functions
+from uiutils import build_page_structure, handle_chat, initialize
 import json
-load_dotenv()
 
-## helper function to convert messages to chat messages
-def convert_messages(messages):
-    converted_messages = []
-    for message in messages:
-        role = message['role']
-        content = message['content']
-        if role == "assisstant":
-            role = MessageRole.ASSISTANT
-        elif role=="system":
-            role = MessageRole.SYSTEM
-        else:
-            role = MessageRole.USER
-        converted_messages.append(ChatMessage(role = role, content = content))
-    return converted_messages
-        
-
-
-# initialize the service and storage context
-debug = LlamaDebugHandler(print_trace_on_end=True)
-callback_manager = CallbackManager(handlers=[debug])
-llm = Bedrock(
-    model=os.environ["BEDROCK_MODEL"],
-    temperature=os.environ["CHAT_TEMPERATURE"],
-    profile_name=os.environ["AWS_PROFILE_NAME"],
-)
-embedding = BedrockEmbedding.from_credentials(
-    aws_profile=os.environ["AWS_PROFILE_NAME"]
-)
-# create a service context using the Bedrock embeddings
-service_context = ServiceContext.from_defaults(
-    llm=llm, embed_model=embedding  # , callback_manager=callback_manager
-)
-
-st.set_page_config(
-    page_title="Chat with Claude",
-    page_icon="💬",
-    layout="centered",
-    initial_sidebar_state="auto",
-    menu_items=None,
-)
-    
-st.title("💬 Chat with Claude 💬")
-
-# add a sidebar for chatting with PDF
-with st.sidebar:
-    st.page_link("main.py", label="Home", icon="🏠")
-    st.page_link("pages/pdf.py", label="PDF", icon="📁")
-    st.page_link("pages/website.py", label="Website", icon="🌐")
-    st.page_link("pages/chat.py", label="Chat", icon="💬")
+initialize()
+build_page_structure("Chat with Bedrock", "💬")
     
 # create 2 tabs. one option is to set the system message for the change
-chat_tab, system_tab = st.tabs(['Chat','Settings'])
-
-with chat_tab:
-    st.subheader("Chat")
-    if "messages" not in st.session_state.keys():
-        st.session_state.messages = [
+    # let the user set a system prompt
+system_prompt = st.text_area(label='System Prompt',
+                                help="Optional System Prompt to change the behavior of the chat"                                 
+)
+if st.button('Update'):
+    if system_prompt != '' and system_prompt!=' ':
+        # wipe out the history and reset the messages
+        messages = [
             {
+                "role": "system",
+                "content": system_prompt
+            },
+            {            
                 "role": "assistant",
                 "content": "I am a helpful assistant. Ask me a question..",
-            }
+            }                
         ]
+        st.session_state.messages = messages
+        st.success('System prompt updated successfull!')
+#chat_tab, system_tab = st.tabs(['Chat','Settings'])
 
-    # check and initialize index
-    if "chat_engine" not in st.session_state.keys():
-        st.session_state.chat_engine = llm
+#with chat_tab:
+handle_chat( clear_session=False )
 
-    if prompt := st.chat_input("Your question: "):
-        st.session_state.messages.append({"role": "user", "content": prompt})
-
-    for message in st.session_state.messages:
-        # skip the system messages
-        if message['role'] != 'system':
-            with st.chat_message(message["role"]):
-                st.write(message["content"])
-                # call the chat engine with user prompt.. variable prompt is defined earlier
-    
-    # if the last message is from a user, now, run the llm    
-    if (st.session_state.messages[-1])["role"] == "user":
-        with st.spinner('Waiting for response from GPT...'):
-            try:
-                response = st.session_state.chat_engine.chat(messages = convert_messages(st.session_state.messages))                
-                response = json.loads(response.json())['message']['content']
-                with st.chat_message('assistant'):
-                    st.write(response) 
-
-                # add the message into the message history
-                st.session_state.messages.append(
-                    {
-                        "role": "assistant",
-                        "content": response
-                    }
-                )
-            except ClientError as e:
-                st.error(f"ClientError: {e}")
-
-with system_tab:
-    # let the user set a system prompt
-    system_prompt = st.text_area(label='System Prompt',
-                                 help="Optional System Prompt to change the behavior of the chat"                                 
-    )
-    if st.button('Update'):
-        if system_prompt != '' and system_prompt!=' ':
-            # wipe out the history and reset the messages
-            messages = [
-                {
-                    "role": "system",
-                    "content": system_prompt
-                },
-                {            
-                    "role": "assistant",
-                    "content": "I am a helpful assistant. Ask me a question..",
-                }                
-            ]
-            st.session_state.messages = messages
-            st.success('System prompt updated successfull!')
+#with system_tab:

--- a/llamaindex/chat_with_website/pages/pdf.py
+++ b/llamaindex/chat_with_website/pages/pdf.py
@@ -1,101 +1,11 @@
 import streamlit as st
-from dotenv import load_dotenv
-import os
-import uuid
 
-from llama_index.core import VectorStoreIndex
-from llama_index.readers.web import SimpleWebPageReader
-from llama_index.llms.bedrock import Bedrock
-from llama_index.core import ServiceContext, StorageContext, load_index_from_storage
-from llama_index.embeddings.bedrock import BedrockEmbedding
-import chromadb
-from llama_index.vector_stores.chroma import ChromaVectorStore
+# import utils and uiutils to re-use code.
+from uiutils import build_page_structure, initialize
+from utils import load_data_from_pdf
 
-# enabling debug
-from llama_index.core.callbacks import LlamaDebugHandler, CallbackManager
-
-# exceptions
-from botocore.exceptions import ClientError
-
-# import pdf reader
-#from llama_index.readers.file.pymu_pdf import PyMuPDFReader
-from PyPDF2 import PdfReader
-from llama_index.core import Document
-
-load_dotenv()
-
-# initialize the service and storage context
-debug = LlamaDebugHandler(print_trace_on_end=True)
-callback_manager = CallbackManager(handlers=[debug])
-llm = Bedrock(
-    model=os.environ["BEDROCK_MODEL"],
-    temperature=os.environ["CHAT_TEMPERATURE"],
-    profile_name=os.environ["AWS_PROFILE_NAME"],
-)
-embedding = BedrockEmbedding.from_credentials(
-    aws_profile=os.environ["AWS_PROFILE_NAME"]
-)
-# create a service context using the Bedrock embeddings
-service_context = ServiceContext.from_defaults(
-    llm=llm, embed_model=embedding  # , callback_manager=callback_manager
-)
-
-dbconn = chromadb.Client(
-    chromadb.config.Settings(
-        is_persistent=True, persist_directory=os.environ["PERSIST_DIR"]
-    )
-)
-chroma_collection = dbconn.get_or_create_collection(os.environ["COLLECTION_NAME"])
-vector_store = ChromaVectorStore(chroma_collection=chroma_collection)
-
-
-def load_data(pdf) -> bool:
-    # now create the uuid
-    id = uuid.uuid4()
-
-    # first write the file to disk
-    bytes_data = pdf.getvalue()
-    #with open('./temp.pdf','wb') as f:
-    #    f.write(bytes_data)
-    reader = PdfReader(pdf)
-    text = ''
-    for page in reader.pages:
-        text += page.extract_text()
-    document = Document(text=text)
-    # fetch the URL
-    #loader = PyMuPDFReader()
-    documents = [document]
-    
-    storage_context = StorageContext.from_defaults(vector_store=vector_store)
-
-    index = VectorStoreIndex.from_documents(
-        documents,        
-        service_context=service_context,
-        storage_context=storage_context,
-        show_progress=True        
-    )
-
-    # index.storage_context.persist(persist_dir=)
-    return True
-
-st.set_page_config(
-    page_title="Chat with your PDF",
-    page_icon="📁",
-    layout="centered",
-    initial_sidebar_state="auto",
-    menu_items=None,
-)
-    
-st.title("📁 Chat with PDF 📁")
-
-# add a sidebar for chatting with PDF
-with st.sidebar:
-    st.page_link("main.py", label="Home", icon="🏠")
-    st.page_link("pages/pdf.py", label="PDF", icon="📁")
-    st.page_link("pages/website.py", label="Website", icon="🌐")
-    st.page_link("pages/chat.py", label="Chat", icon="💬")
-    
-
+initialize()
+build_page_structure("Upload your PDF", "📁")
 
 st.subheader("Upload PDF")
 pdf = st.file_uploader(
@@ -104,53 +14,14 @@ pdf = st.file_uploader(
     accept_multiple_files=False,
     help="Local PDF file that you want to chat with.")
 
-
 if st.button(label="Load Data"):
     with st.spinner("Loading data.."):
-        if load_data(pdf=pdf) == True:
-            st.write(f"Loaded PDF successfully.")
+        result = load_data_from_pdf(
+            pdf=pdf, 
+            vector_store=st.session_state.vector_store, 
+            service_context=st.session_state.service_context
+        )
+        if result==True:
+            st.success(f"Loaded PDF successfully.")
         else:
             st.error("Unable to load the data.")
-
-
-st.subheader("Chat")
-if "messages" not in st.session_state.keys():
-    st.session_state.messages = [
-        {
-            "role": "assistant",
-            "content": "Ask me a question about the website that was just loaded..",
-        }
-    ]
-
-# check and initialize index
-if "chat_engine" not in st.session_state.keys():
-    index = VectorStoreIndex.from_vector_store(
-        vector_store,
-        service_context=service_context,
-    )
-    st.session_state.chat_engine = index.as_chat_engine(
-        chat_mode="context", verbose=True
-    )
-
-if prompt := st.chat_input("Your question: "):
-    st.session_state.messages.append({"role": "user", "content": prompt})
-
-for message in st.session_state.messages:
-    with st.chat_message(message["role"]):
-        st.write(message["content"])
-        # call the chat engine with user prompt.. variable prompt is defined earlier
-
-
-# if the last message is from a user, now, run the llm
-if st.session_state.messages[-1]["role"] != "assistant":
-    with st.spinner('Waiting for response from GPT...'):
-        try:
-            response = st.session_state.chat_engine.chat(message=prompt)
-            st.write(response.response)
-
-            # add the message into the message history
-            st.session_state.messages.append(
-                {"role": "assistant", "content": response.response}
-            )
-        except ClientError as e:
-            st.error(f"ClientError: {e}")

--- a/llamaindex/chat_with_website/pages/website.py
+++ b/llamaindex/chat_with_website/pages/website.py
@@ -1,134 +1,20 @@
 import streamlit as st
-from dotenv import load_dotenv
-import os
-import uuid
+from uiutils import build_page_structure, initialize
+from utils import load_data_from_url 
 
-from llama_index.core import VectorStoreIndex
-from llama_index.readers.web import SimpleWebPageReader
-from llama_index.llms.bedrock import Bedrock
-from llama_index.core import ServiceContext, StorageContext, load_index_from_storage
-from llama_index.embeddings.bedrock import BedrockEmbedding
-import chromadb
-from llama_index.vector_stores.chroma import ChromaVectorStore
-
-# enabling debug
-from llama_index.core.callbacks import LlamaDebugHandler, CallbackManager
-
-# exceptions
-from botocore.exceptions import ClientError
-
-load_dotenv()
-
-# initialize the service and storage context
-debug = LlamaDebugHandler(print_trace_on_end=True)
-callback_manager = CallbackManager(handlers=[debug])
-llm = Bedrock(
-    model=os.environ["BEDROCK_MODEL"],
-    temperature=os.environ["CHAT_TEMPERATURE"],
-    profile_name=os.environ["AWS_PROFILE_NAME"],
-)
-embedding = BedrockEmbedding.from_credentials(
-    aws_profile=os.environ["AWS_PROFILE_NAME"]
-)
-# create a service context using the Bedrock embeddings
-service_context = ServiceContext.from_defaults(
-    llm=llm, embed_model=embedding  # , callback_manager=callback_manager
-)
-
-dbconn = chromadb.Client(
-    chromadb.config.Settings(
-        is_persistent=True, persist_directory=os.environ["PERSIST_DIR"]
-    )
-)
-chroma_collection = dbconn.get_or_create_collection(os.environ["COLLECTION_NAME"])
-vector_store = ChromaVectorStore(chroma_collection=chroma_collection)
-
-
-def load_data(url: str) -> bool:
-    # now create the uuid
-    id = uuid.uuid4()
-    # fetch the URL
-    documents = SimpleWebPageReader(html_to_text=True).load_data(urls=[url])
-    storage_context = StorageContext.from_defaults(vector_store=vector_store)
-
-    index = VectorStoreIndex.from_documents(
-        documents,        
-        service_context=service_context,
-        storage_context=storage_context        
-    )
-
-    # index.storage_context.persist(persist_dir=)
-    return True
-
-
-st.set_page_config(
-    page_title="Chat with your WebPage",
-    page_icon="🦙",
-    layout="centered",
-    initial_sidebar_state="auto",
-    menu_items=None,
-)
-
-# add a sidebar for chatting with PDF
-with st.sidebar:
-    st.page_link("main.py", label="Home", icon="🏠")
-    st.page_link("pages/pdf.py", label="PDF", icon="📁")
-    st.page_link("pages/website.py", label="Website", icon="🌐")
-    st.page_link("pages/chat.py", label="Chat", icon="💬")
-    
-
-st.title("🦙 Chat with WebPage 🦙")
-
-tab_load, tab_chat = st.tabs(["Load URL", "Chat"])
-
+initialize()
+build_page_structure("Add your WebPage", "🌐")
 
 st.subheader("Load URL")
 url = st.text_input(label="URL")
 if st.button(label="Load Data"):
     with st.spinner("Loading data.."):
-        if load_data(url=url) == True:
-            st.write(f"Loaded {url} successfully.")
+        result = load_data_from_url(
+            url=url,
+            vector_store=st.session_state.vector_store,
+            service_context=st.session_state.service_context
+        )
+        if result == True:
+            st.success(f"Loaded {url} successfully.")
         else:
             st.error("Unable to load the data.")
-
-
-st.subheader("Chat")
-if "messages" not in st.session_state.keys():
-    st.session_state.messages = [
-        {
-            "role": "assistant",
-            "content": "Ask me a question about the website that was just loaded..",
-        }
-    ]
-
-# check and initialize index
-if "chat_engine" not in st.session_state.keys():
-    index = VectorStoreIndex.from_vector_store(
-        vector_store,
-        service_context=service_context,
-    )
-    st.session_state.chat_engine = index.as_chat_engine(
-        chat_mode="context", verbose=True
-    )
-
-if prompt := st.chat_input("Your question: "):
-    st.session_state.messages.append({"role": "user", "content": prompt})
-
-for message in st.session_state.messages:
-    with st.chat_message(message["role"]):
-        st.write(message["content"])
-        # call the chat engine with user prompt.. variable prompt is defined earlier
-
-
-# if the last message is from a user, now, run the llm
-if st.session_state.messages[-1]["role"] != "assistant":
-    try:
-        response = st.session_state.chat_engine.chat(message=prompt)
-        st.write(response.response)
-
-        # add the message into the message history
-        st.session_state.messages.append(
-            {"role": "assistant", "content": response.response}
-        )
-    except ClientError as e:
-        st.error(f"ClientError: {e}")

--- a/llamaindex/chat_with_website/uiutils.py
+++ b/llamaindex/chat_with_website/uiutils.py
@@ -1,0 +1,67 @@
+import streamlit as st
+from utils import get_vector_store_index_based_chat_engine, get_service_context_and_llm, get_vector_store
+from botocore.exceptions import ClientError
+
+def initialize():
+    if "vector_store" not in st.session_state.keys():
+        # setup LLM and service context for Bedrock
+        st.session_state.service_context,st.session_state.llm = get_service_context_and_llm()
+        # get the vector store
+        st.session_state.vector_store = get_vector_store()
+
+
+def build_page_structure(title:str, icon:str)->None:
+    st.set_page_config(
+    page_title=title,
+    page_icon=icon,
+    layout="centered",
+    initial_sidebar_state="auto",
+    menu_items=None,
+    )
+    
+    st.title(f"{icon} {title} {icon}")
+
+    # add a sidebar for chatting with PDF
+    with st.sidebar:
+        st.page_link("main.py", label="Home", icon="🏠")
+        st.page_link("pages/pdf.py", label="PDF", icon="📁")
+        st.page_link("pages/website.py", label="Website", icon="🌐")
+        st.page_link("pages/chat.py", label="Chat", icon="💬")
+
+def handle_chat(clear_session:bool=True)->None:
+    st.subheader("Chat")
+    if "messages" not in st.session_state.keys() or clear_session==True:
+        st.session_state.messages = [
+            {
+                "role": "assistant",
+                "content": "Ask me a question about the website that was just loaded..",
+            }
+        ]
+    
+    # check and initialize index
+    if "chat_engine" not in st.session_state.keys():        
+        st.session_state.chat_engine = get_vector_store_index_based_chat_engine(
+            vector_store=st.session_state.vector_store, 
+            service_context=st.session_state.service_context
+        )
+
+    if prompt := st.chat_input("Your question: "):
+        st.session_state.messages.append({"role": "user", "content": prompt})
+
+    for message in st.session_state.messages:
+        with st.chat_message(message["role"]):
+            st.write(message["content"])            
+
+    # if the last message is from a user, now, run the llm
+    if st.session_state.messages[-1]["role"] == "user":
+        with st.spinner('Waiting for response from GPT...'):
+            try:
+                response = st.session_state.chat_engine.chat(message=prompt)
+                st.write(response.response)
+
+                # add the message into the message history
+                st.session_state.messages.append(
+                    {"role": "assistant", "content": response.response}
+                )
+            except ClientError as e:
+                st.error(f"ClientError: {e}")

--- a/llamaindex/chat_with_website/utils.py
+++ b/llamaindex/chat_with_website/utils.py
@@ -1,0 +1,123 @@
+from dotenv import load_dotenv
+import os
+import uuid
+
+from llama_index.core.llms import ChatMessage, MessageRole
+from llama_index.llms.bedrock import Bedrock
+from llama_index.core import ServiceContext, StorageContext, VectorStoreIndex, Document
+from llama_index.embeddings.bedrock import BedrockEmbedding
+import chromadb
+from llama_index.vector_stores.chroma import ChromaVectorStore
+# enabling debug
+from llama_index.core.callbacks import LlamaDebugHandler, CallbackManager
+# libraries for PDF reader
+from PyPDF2 import PdfReader
+# libraries for website reader
+from llama_index.readers.web import SimpleWebPageReader
+
+
+# exceptions
+from botocore.exceptions import ClientError
+
+load_dotenv()
+## helper function to convert messages to chat messages
+def convert_messages(messages):
+    converted_messages = []
+    for message in messages:
+        role = message['role']
+        content = message['content']
+        if role == "assisstant":
+            role = MessageRole.ASSISTANT
+        elif role=="system":
+            role = MessageRole.SYSTEM
+        else:
+            role = MessageRole.USER
+        converted_messages.append(ChatMessage(role = role, content = content))
+    return converted_messages
+
+def get_service_context_and_llm():
+    # initialize the service and storage context
+    debug = LlamaDebugHandler(print_trace_on_end=True)
+    callback_manager = CallbackManager(handlers=[debug])
+
+    llm = Bedrock(
+        model=os.environ["BEDROCK_MODEL"],
+        temperature=os.environ["CHAT_TEMPERATURE"],
+        profile_name=os.environ["AWS_PROFILE_NAME"],
+    )
+    embedding = BedrockEmbedding.from_credentials(
+        aws_profile=os.environ["AWS_PROFILE_NAME"]
+    )
+
+    # to read on EC2/AWS instances, use these methods instead
+    # https://medium.com/@dminhk/llamaindex-q-a-over-your-data-using-amazon-bedrock-and-streamlit-1e52a096ec7c
+    # create a service context using the Bedrock embeddings
+    service_context = ServiceContext.from_defaults(
+        llm=llm, embed_model=embedding  # , callback_manager=callback_manager
+    )
+    return (service_context,llm)
+
+def get_vector_store():
+    dbconn = chromadb.Client(
+        chromadb.config.Settings(
+        is_persistent=True, persist_directory=os.environ["PERSIST_DIR"]
+        )
+    )
+    chroma_collection = dbconn.get_or_create_collection(os.environ["COLLECTION_NAME"])
+    vector_store = ChromaVectorStore(chroma_collection=chroma_collection)
+    return vector_store
+
+def load_data_from_url(url: str, vector_store: VectorStoreIndex, service_context:ServiceContext) -> bool:
+    # now create the uuid
+    id = uuid.uuid4()
+    # fetch the URL
+    documents = SimpleWebPageReader(html_to_text=True).load_data(urls=[url])
+    storage_context = StorageContext.from_defaults(vector_store=vector_store)
+
+    index = VectorStoreIndex.from_documents(
+        documents,        
+        service_context=service_context,
+        storage_context=storage_context        
+    )
+
+    # index.storage_context.persist(persist_dir=)
+    return True
+
+def load_data_from_pdf(pdf, vector_store: VectorStoreIndex, service_context:ServiceContext) -> bool:
+    # now create the uuid
+    id = uuid.uuid4()
+
+    # first write the file to disk
+    bytes_data = pdf.getvalue()
+    #with open('./temp.pdf','wb') as f:
+    #    f.write(bytes_data)
+    reader = PdfReader(pdf)
+    text = ''
+    for page in reader.pages:
+        text += page.extract_text()
+    document = Document(text=text)
+    # fetch the URL
+    #loader = PyMuPDFReader()
+    documents = [document]
+    
+    storage_context = StorageContext.from_defaults(vector_store=vector_store)
+
+    index = VectorStoreIndex.from_documents(
+        documents,        
+        service_context=service_context,
+        storage_context=storage_context,
+        show_progress=True        
+    )
+
+    # index.storage_context.persist(persist_dir=)
+    return True
+
+def get_vector_store_index_based_chat_engine(vector_store: VectorStoreIndex, service_context:ServiceContext) -> bool:
+    index = VectorStoreIndex.from_vector_store(
+        vector_store,
+        service_context=service_context,
+    )
+    chat_engine = index.as_chat_engine(
+            chat_mode="context", verbose=True
+    )
+    return chat_engine


### PR DESCRIPTION
Moved the common LLM related code to `utils.py` and moved the common UI code to `uiutils.py`. Simplified the page for `chat`, `web` and `pdf` pages as a result of the above 2 change.